### PR TITLE
Port firefox webextension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist/scripts/popup.js
 dist/styles/popup.css
+*.xpi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist/scripts/popup.js
 dist/styles/popup.css
 *.xpi
+.idea

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -4,8 +4,15 @@
   "description": "The easiest way to measure your performance budget",
   "homepage_url": "https://github.com/zenorocha/browser-calories-chrome",
   "version": "1.2.2",
+  "applications": {
+    "gecko": {
+      "id": "calories@browserdiet.com",
+      "strict_min_version": "45.0"
+    }
+  },
   "browser_action": {
-    "default_popup": "popup.html"
+    "default_popup": "popup.html",
+    "default_icon": "images/icon-48.png"
   },
   "icons": {
     "16" : "images/icon-16.png",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-preset-metal": "^3.1.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "metal-component": "^1.0.0-rc.12",
     "node-sass": "^3.4.2",
     "onchange": "^2.2.0",
     "parallelshell": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "node-sass": "^3.4.2",
     "onchange": "^2.2.0",
     "parallelshell": "^2.0.0",
-    "watchify": "^3.7.0"
+    "watchify": "^3.7.0",
+    "zip-folder": "^1.0.0"
   },
   "scripts": {
     "start": "npm run build",
@@ -28,7 +29,7 @@
     "watch:scripts": "onchange 'src/scripts/*.js' -- npm run build:scripts",
     "watch:styles": "onchange 'src/styles/*.scss' -- npm run build:styles",
     "package": "npm run package:firefox",
-    "package:firefox": "cd dist && zip -r ../browser-calories.xpi * && cd .."
+    "package:firefox": "node tools/firefox-xpi-packager.js"
   },
   "babel": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "build:styles": "node-sass src/styles/popup.scss dist/styles/popup.css -q",
     "watch": "parallelshell 'npm run watch:scripts' 'npm run watch:styles'",
     "watch:scripts": "onchange 'src/scripts/*.js' -- npm run build:scripts",
-    "watch:styles": "onchange 'src/styles/*.scss' -- npm run build:styles"
+    "watch:styles": "onchange 'src/styles/*.scss' -- npm run build:styles",
+    "package": "npm run package:firefox",
+    "package:firefox": "cd dist && zip -r ../browser-calories.xpi * && cd .."
   },
   "babel": {
     "plugins": [

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,23 @@ npm install
 npm start
 ```
 
+## Chrome testing
+
 3) Go to `chrome://extensions`
 
 4) Click on `Load unpacked extension...`
 
 5) Select the `dist` folder
+
+## Firefox testing (Requires firefox dev edition or nightly)
+
+3) Go to `about:debugging`
+
+4) Click on `Load temporary Add-on`
+
+5) Select the `manifest.json` inside the `dist` folder
+
+More info at [MDN - Packaging and Running WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Packaging_and_Installation)
 
 ## Credits
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -26,14 +26,12 @@ class App extends JSXComponent {
       // Firefox has no sync right now...
       // The bug tracking this implementation is at https://bugzilla.mozilla.org/show_bug.cgi?id=1220494
       chrome.storage.local.get(defaultBudget, (data) => {
-        console.log(data);
         this.setState({
           budget: data
         });
       });
     } else {
       chrome.storage.sync.get(defaultBudget, (data) => {
-        console.log(data);
         this.setState({
           budget: data
         });

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -49,18 +49,20 @@ class App extends JSXComponent {
         return response.json();
       })
       .then((response) => {
-        
+
+        document.body.style.overflow = "auto"; // get the scrollbars back for the long table.
+
         // Response doesn't contain status code in here.
         if (!response.hasOwnProperty("html") ) {
-          this.setState({
-            error: response
-          });         
-        } else {
-          this.setState({
-            success: response
+              this.setState({
+                error: response
+              });
+            } else {
+              this.setState({
+                success: response
+              });
+            }
           });
-        }
-      });
   }
 
   render() {

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -24,6 +24,7 @@ class App extends JSXComponent {
   getBudget() {
     if (!chrome.storage.hasOwnProperty("sync")) {
       // Firefox has no sync right now...
+      // The bug tracking this implementation is at https://bugzilla.mozilla.org/show_bug.cgi?id=1220494
       chrome.storage.local.get(defaultBudget, (data) => {
         console.log(data);
         this.setState({

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -22,12 +22,22 @@ class App extends JSXComponent {
   }
 
   getBudget() {
-    chrome.storage.local.get(defaultBudget, (data) => {
-      console.log(data);
-      this.setState({
-        budget: data
+    if (!chrome.storage.hasOwnProperty("sync")) {
+      // Firefox has no sync right now...
+      chrome.storage.local.get(defaultBudget, (data) => {
+        console.log(data);
+        this.setState({
+          budget: data
+        });
       });
-    });
+    } else {
+      chrome.storage.sync.get(defaultBudget, (data) => {
+        console.log(data);
+        this.setState({
+          budget: data
+        });
+      });
+    }
   }
 
   fetchURL() {

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -6,11 +6,13 @@ import defaultBudget from '../data/budget';
 
 class App extends JSXComponent {
   attached() {
+    console.log("Attached...");
     this.getURL();
     this.getBudget();
   }
 
   getURL() {
+    console.log("GetURL...");
     chrome.tabs.query({
       active: true,
       currentWindow: true
@@ -22,6 +24,7 @@ class App extends JSXComponent {
   }
 
   getBudget() {
+    console.log("GetBudget...");
     chrome.storage.sync.get(defaultBudget, (data) => {
       this.setState({
         budget: data
@@ -30,19 +33,27 @@ class App extends JSXComponent {
   }
 
   fetchURL() {
+    console.log("fetchURL...");
     let api = 'https://calories.browserdiet.com/?url=' + encodeURIComponent(this.url);
 
     fetch(api)
       .then((response) => {
+        console.log("return from fetch");
+        console.log(response);
         return response.json();
       })
       .then((response) => {
-        if (response.statusCode >= 400) {
+        console.log("after fetch");
+        console.log(response);
+        
+        // Response doesn't contain status code in here.
+        if (!response.hasOwnProperty("html") ) {
+          console.log("error!!!!");
           this.setState({
             error: response
-          });
-        }
-        else {
+          });         
+        } else {
+          console.log("success");
           this.setState({
             success: response
           });
@@ -51,13 +62,22 @@ class App extends JSXComponent {
   }
 
   render() {
+    /*
+    State is not being set or accessed. All calls such as `this.success` return undefined.
+    */
+    console.log("Render...");
+    console.log(this.success);
+    console.log(this.budget);
     if (this.success && this.budget) {
+      console.log("success on render");
       return <Result url={this.url} success={this.success} budget={this.budget} />;
     }
     else if (this.error) {
+      console.log("fail on render");
       return <Failure url={this.url} error={this.error} />;
     }
     else {
+      console.log("loader on render: " + this.url); 
       return <Loader url={this.url} />;
     }
   }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -6,13 +6,11 @@ import defaultBudget from '../data/budget';
 
 class App extends JSXComponent {
   attached() {
-    console.log("Attached...");
     this.getURL();
     this.getBudget();
   }
 
   getURL() {
-    console.log("GetURL...");
     chrome.tabs.query({
       active: true,
       currentWindow: true
@@ -24,8 +22,8 @@ class App extends JSXComponent {
   }
 
   getBudget() {
-    console.log("GetBudget...");
-    chrome.storage.sync.get(defaultBudget, (data) => {
+    chrome.storage.local.get(defaultBudget, (data) => {
+      console.log(data);
       this.setState({
         budget: data
       });
@@ -33,27 +31,20 @@ class App extends JSXComponent {
   }
 
   fetchURL() {
-    console.log("fetchURL...");
     let api = 'https://calories.browserdiet.com/?url=' + encodeURIComponent(this.url);
 
     fetch(api)
       .then((response) => {
-        console.log("return from fetch");
-        console.log(response);
         return response.json();
       })
       .then((response) => {
-        console.log("after fetch");
-        console.log(response);
         
         // Response doesn't contain status code in here.
         if (!response.hasOwnProperty("html") ) {
-          console.log("error!!!!");
           this.setState({
             error: response
           });         
         } else {
-          console.log("success");
           this.setState({
             success: response
           });
@@ -62,22 +53,13 @@ class App extends JSXComponent {
   }
 
   render() {
-    /*
-    State is not being set or accessed. All calls such as `this.success` return undefined.
-    */
-    console.log("Render...");
-    console.log(this.success);
-    console.log(this.budget);
     if (this.success && this.budget) {
-      console.log("success on render");
       return <Result url={this.url} success={this.success} budget={this.budget} />;
     }
     else if (this.error) {
-      console.log("fail on render");
       return <Failure url={this.url} error={this.error} />;
     }
     else {
-      console.log("loader on render: " + this.url); 
       return <Loader url={this.url} />;
     }
   }

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -1,12 +1,15 @@
 var defaultBudget = require('../data/budget');
 
+// Firefox has no sync yet. Cue: https://bugzilla.mozilla.org/show_bug.cgi?id=1220494
+var chromeStorage = chrome.storage.sync || chrome.storage.local; 
+
 document.addEventListener('DOMContentLoaded', restore);
 
 function restore() {
   var form = document.querySelector('form');
   form.addEventListener('submit', save);
 
-  chrome.storage.sync.get(defaultBudget, function(data) {
+  chromeStorage.get(defaultBudget, function(data) {
     form.html.value  = data.html;
     form.image.value = data.image;
     form.css.value   = data.css;
@@ -28,7 +31,7 @@ function save(e) {
 
   budget.total = budget.html + budget.image + budget.css + budget.js + budget.other;
 
-  chrome.storage.sync.set(budget, function() {
+  chromeStorage.set(budget, function() {
     var status = document.querySelector('.status');
     status.style.display = 'inline-block';
 

--- a/src/scripts/result.js
+++ b/src/scripts/result.js
@@ -47,6 +47,7 @@ class Result extends JSXComponent {
   }
 
   render() {
+    console.log("render result");
     let cleanUrl = this.config.url.replace(/^http(s)?\:\/\/(www.)?/i, "").replace(/\/$/, "");
     let siteBytes = this.toBytes(this.config.success);
     let budgetBytes = this.toBytes(this.config.budget);

--- a/src/scripts/result.js
+++ b/src/scripts/result.js
@@ -47,7 +47,6 @@ class Result extends JSXComponent {
   }
 
   render() {
-    console.log("render result");
     let cleanUrl = this.config.url.replace(/^http(s)?\:\/\/(www.)?/i, "").replace(/\/$/, "");
     let siteBytes = this.toBytes(this.config.success);
     let budgetBytes = this.toBytes(this.config.budget);

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -4,6 +4,7 @@ body {
   font-size: small;
   line-height: 1.4;
   margin: 0;
+  overflow: hidden;
 }
 
 a {

--- a/tools/firefox-xpi-packager.js
+++ b/tools/firefox-xpi-packager.js
@@ -1,0 +1,12 @@
+var zipFolder = require('zip-folder');
+var fs = require('fs');
+
+process.chdir("dist")
+ 
+zipFolder('./', '../browser-calories.xpi', function(err) {
+	if(err) {
+		console.log('oh no!', err);
+	} else {
+		console.log('WebExtension packaged as browser-calories.xpi');
+	}
+});


### PR DESCRIPTION
This is a working version for Firefox. The following relevant changes were made:
- Changed `manifest.json` to include fields needed for Firefox
- Changed some checks on `app.js` to use `hasOwnProperty()` 
- Added a branch on `getBudget()` to use `chrome.storage.local` on Firefox instead of `chrome.storage.sync` which is not available.
- Added new `package` and `package:firefox` script entries to `package.json` to help package the WebExtension for Firefox.
